### PR TITLE
Add ROS1 dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ wstool update -t src -j4
 For dependencies available through binaries, use rosdep.
 This package depends on [GDAL](https://gdal.org/index.html) to read georeferenced images and GeoTIFF files.
 ```
+apt update
 rosdep update
 source /opt/ros/noetic/setup.bash
 rosdep install --from-paths src --ignore-src -y

--- a/README.md
+++ b/README.md
@@ -7,7 +7,30 @@ This package includes a global planner based on Dubins RRT* enabling low altitud
 ![overview3](https://github.com/ethz-asl/terrain-navigation/assets/5248102/90e43b60-ea8c-49db-9fb3-257b145fc35c)
 
 ## Setup
-Install the dependencies. This package depends on gdal, to read georeferenced images and GeoTIFF files.
+
+### Setting up the Build Environment using Docker
+
+If your operating system doesn't support ROS 1 noetic, docker is a great alternative. 
+
+First, create the image, with the build context at the root of this repo
+
+```
+docker build --file docker/Dockerfile --tag terrain-navigation-ros1 .
+```
+
+You can see the image exists:
+```
+docker images
+>>> REPOSITORY                TAG       IMAGE ID       CREATED        SIZE
+>>> terrain-navigation-ros1   latest    5565f845ab4f   2 weeks ago    774MB
+```
+
+Next, run the image, mounting in the source into a workspace. All the dependencies are now installed.
+```
+docker run --network=host -it -v $(pwd):/root/catkin_ws/src/terrain-navigation -w /root/catkin_ws terrain-navigation-ros1 bash
+```
+
+### Running the Build
 
 Configure the catkin workspace
 ```
@@ -15,12 +38,18 @@ catkin config --extend "/opt/ros/noetic"
 catkin config --merge-devel
 ```
 
-Pull in dependencies using rosinstall / rosdep
+For dependencies that do not have binaries available, pull them in using rosinstall.
 ```
 wstool init src src/terrain-navigation/dependencies.rosinstall
 wstool update -t src -j4
+```
+
+For dependencies available through binaries, use rosdep.
+This package depends on [GDAL](https://gdal.org/index.html) to read georeferenced images and GeoTIFF files.
+```
 rosdep update
-rosdep install --from-paths src --ignore-src -y --rosdistro noetic
+source /opt/ros/noetic/setup.bash
+rosdep install --from-paths src --ignore-src -y
 ```
 
 Build the package
@@ -30,6 +59,7 @@ catkin build -j$(nproc) -l$(nproc) terrain_navigation_ros
 ```
 
 ## Running with PX4 SITL(Software-In-The-Loop)
+
 To setup PX4, clone the [ETHZ ASL PX4 autopilot project](https://github.com/ethz-asl/ethzasl_fw_px4/tree/pr-hinwil-testing)
 The setup instructions can be found in the [documentation](https://docs.px4.io/main/en/dev_setup/dev_env_linux_ubuntu.html)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,6 @@
 # https://github.com/osrf/docker_images/blob/df19ab7d5993d3b78a908362cdcd1479a8e78b35/ros/noetic/ubuntu/focal/ros-core/Dockerfile
-FROM ros:noetic-ros-core-focal
+FROM ros:noetic-ros-core-focal as repo-deps
+# This layer installs basic tools and the direct dependencies of terrain-navigation.
 
 SHELL ["/bin/bash", "-c"]
 
@@ -26,4 +27,18 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive rosdep install --from-paths src --ignore-src -r -y \
     && python3 -m pip install \
         wstool \
+    && rm -rf /var/lib/apt/lists/*
+
+
+FROM repo-deps as all-deps
+# This layer installs dependencies of the other source packages.
+
+COPY dependencies.rosinstall src/terrain-navigation/dependencies.rosinstall
+RUN wstool init src src/terrain-navigation/dependencies.rosinstall
+RUN wstool update -t src -j4
+
+RUN apt-get update \
+    && rosdep update \
+    && source /opt/ros/noetic/setup.bash \
+    && rosdep install --from-paths src --ignore-src -y \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,29 @@
+# https://github.com/osrf/docker_images/blob/df19ab7d5993d3b78a908362cdcd1479a8e78b35/ros/noetic/ubuntu/focal/ros-core/Dockerfile
+FROM ros:noetic-ros-core-focal
+
+SHELL ["/bin/bash", "-c"]
+
+WORKDIR /root/catkin_ws/src/terrain-navigation
+
+COPY mav_planning_rviz/package.xml mav_planning_rviz/package.xml
+COPY planner_msgs/package.xml planner_msgs/package.xml
+COPY terrain_navigation/package.xml terrain_navigation/package.xml
+COPY terrain_navigation_ros/package.xml terrain_navigation_ros/package.xml
+COPY terrain_planner/package.xml terrain_planner/package.xml
+COPY terrain_planner_benchmark/package.xml terrain_planner_benchmark/package.xml
+
+WORKDIR /root/catkin_ws/
+
+RUN apt-get update \
+    # https://ros.org/reps/rep-2001.html#dev-tools
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ros-dev-tools \
+        ros-noetic-catkin \
+        python3-catkin-tools \
+        python3-pip \
+    && rosdep init \
+    && rosdep update \
+    && DEBIAN_FRONTEND=noninteractive rosdep install --from-paths src --ignore-src -r -y \
+    && python3 -m pip install \
+        wstool \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Background

Modeled after https://github.com/nachovizzo/ros_in_docker, but just the dockerfile support. compose and devcontainers can come later as they are not essential.
I also clarify install instructions in README, as environment setup is decoupled from building. 

The goal of this PR is simply to get things compiling. Supporting GUI (RVIZ) and everything can be a follow up as that's a bit tricky. 

One aspect to decide is whether to bring the other repos in during the docker build with wstool (easy for users). Alternatively, we could allow/require them to already be checked out in the local environment, which would allow people to use their own modifications of the other libraries. A selectable way to manage this would be through the use of multi-stage dockerfiles. 

Depending on when it's done, rosdep will still need to be run. 

## Tickets

Relates to  #6 
Depends on #10
Depends on #7 
Depends on #15 
