### PR TITLE
Depend on gdal where it's used with rosdep

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ This package includes a global planner based on Dubins RRT* enabling low altitud
 
 ## Setup
 Install the dependencies. This package depends on gdal, to read georeferenced images and GeoTIFF files.
-```
-apt install libgdal-dev
-```
+
 Configure the catkin workspace
 ```
 catkin config --extend "/opt/ros/noetic"

--- a/terrain_navigation/package.xml
+++ b/terrain_navigation/package.xml
@@ -17,7 +17,9 @@
   <build_depend>eigen_catkin</build_depend>
   <build_depend>grid_map_core</build_depend>
   <build_depend>grid_map_geo</build_depend>
+  <build_depend>libgdal-dev</build_depend>
   <run_depend>eigen_catkin</run_depend>
+  <run_depend>gdal-bin</run_depend>
   <export>
   </export>
 </package>

--- a/terrain_planner_benchmark/package.xml
+++ b/terrain_planner_benchmark/package.xml
@@ -24,6 +24,7 @@
   <build_depend>terrain_navigation</build_depend>
   <build_depend>terrain_planner</build_depend>
   <run_depend>eigen_catkin</run_depend>
+  <run_depend>python3-gdal</run_depend>
   <export>
   </export>
 </package>


### PR DESCRIPTION
Rosdep has support for gdal through three packages.

`libgdal-dev` has the header files, libraries, and cmake files. IT depends on gdal-bin.
`gdal-bin` is the runtime libraries.
`python3-gdal` is the pyhon part of gdal. 

Since these are all used, they can be distributed by the package.xml.

The purpose of doing this is to remove the need to manually install `libgdal-dev`, which is only a useful instruction on ubuntu. For all the other platforms that can run ROS1, they need different instructions, which is hard to maintain. Rosdep is the standard and platform-independent way to manage dependencies in ROS 1 and ROS 2. 


To find the sources, I searched here:
https://github.com/search?q=repo%3Aros%2Frosdistro%20gdal&type=code


One thing I noticed is that `terrain_planner` references gdal in the CMakeLists, however it's not actually used there. If the package isn't used, perhaps it doesn't need to be found and linked to. This increases build time, code maintenance, and coupling. Consider removing it from `terrain_planner`?
