### PR TITLE
Remove ompl installation from build tests

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -27,9 +27,6 @@ jobs:
       run: |
         apt update
         apt install -y python3-wstool libgdal-dev ros-${{matrix.config.rosdistro}}-tf2-geometry-msgs
-        wget https://ompl.kavrakilab.org/install-ompl-ubuntu.sh
-        chmod +x ./install-ompl-ubuntu.sh
-        ./install-ompl-ubuntu.sh
       shell: bash
     - name: Build Test
       working-directory: 


### PR DESCRIPTION
**Problem Description**
This PR removes manual OMPL installation from the build tests

- Decreases dependency install step from 17 minutes -> 21 seconds (Thanks @Ryanf55 !)

**Additional Context**
- Follow up PR of https://github.com/ethz-asl/terrain-navigation/pull/9