### PR TITLE
Add find_package for planner_msgs

### DIFF
--- a/terrain_navigation_ros/CMakeLists.txt
+++ b/terrain_navigation_ros/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(catkin REQUIRED COMPONENTS
   grid_map_core
   grid_map_cv
   grid_map_msgs
+  planner_msgs
   grid_map_ros
   grid_map_pcl
   grid_map_geo


### PR DESCRIPTION
Add an explicit find_package of catkin with required components on planner_msgs. 

Catkin will then link it to the rest of the library as part of the `catkin_LIBRARIES` variable.

Closes #14 