### PR TITLE
Add instructions to README for px4 for ROS noetic with gazebo classic

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,39 +14,39 @@ If your operating system doesn't support ROS 1 noetic, docker is a great alterna
 
 First, create the image, with the build context at the root of this repo
 
-```
+```Bash
 docker build --file docker/Dockerfile --tag terrain-navigation-ros1 .
 ```
 
 You can see the image exists:
-```
+```Bash
 docker images
 >>> REPOSITORY                TAG       IMAGE ID       CREATED        SIZE
 >>> terrain-navigation-ros1   latest    5565f845ab4f   2 weeks ago    774MB
 ```
 
 Next, run the image, mounting in the source into a workspace. All the dependencies are now installed.
-```
+```Bash
 docker run --network=host -it -v $(pwd):/root/catkin_ws/src/terrain-navigation -w /root/catkin_ws terrain-navigation-ros1 bash
 ```
 
 ### Running the Build
 
 Configure the catkin workspace
-```
+```Bash
 catkin config --extend "/opt/ros/noetic"
 catkin config --merge-devel
 ```
 
 For dependencies that do not have binaries available, pull them in using rosinstall.
-```
+```Bash
 wstool init src src/terrain-navigation/dependencies.rosinstall
 wstool update -t src -j4
 ```
 
 For dependencies available through binaries, use rosdep.
 This package depends on [GDAL](https://gdal.org/index.html) to read georeferenced images and GeoTIFF files.
-```
+```Bash
 apt update
 rosdep update
 source /opt/ros/noetic/setup.bash
@@ -54,7 +54,7 @@ rosdep install --from-paths src --ignore-src -y
 ```
 
 Build the package
-```
+```Bash
 catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -DCATKIN_ENABLE_TESTING=False
 catkin build -j$(nproc) -l$(nproc) terrain_navigation_ros
 ```
@@ -62,10 +62,35 @@ catkin build -j$(nproc) -l$(nproc) terrain_navigation_ros
 ## Running with PX4 SITL(Software-In-The-Loop)
 
 To setup PX4, clone the [ETHZ ASL PX4 autopilot project](https://github.com/ethz-asl/ethzasl_fw_px4/tree/pr-hinwil-testing)
-The setup instructions can be found in the [documentation](https://docs.px4.io/main/en/dev_setup/dev_env_linux_ubuntu.html)
+The setup instructions can be found in the [documentation](https://docs.px4.io/main/en/dev_setup/dev_env_linux_ubuntu.html) for the latest dependencies.
 
-The default launch file can be run as the following command. 
+For Ubuntu 20.04+ROS noetic with Gazebo classic:
+
+```Bash
+git clone https://github.com/ethz-asl/ethzasl_fw_px4.git --branch pr-hinwil-testing --recursive
+cd ..
+cd ethzasl_fw_px4
+bash ./Tools/setup/ubuntu.sh
+
+make px4_sitl gazebo
 ```
+
+Do source the relevant environment variables before launching terrain navigation. For instance, for Ubuntu 20.04 + ROS Noetic + Gazebo classic:
+
+```Bash
+px4_dir=~/ethzasl_fw_px4
+source $px4_dir/Tools/simulation/gazebo/setup_gazebo.bash $px4_dir $px4_dir/build/px4_sitl_default
+export ROS_PACKAGE_PATH=$ROS_PACKAGE_PATH:$px4_dir
+export ROS_PACKAGE_PATH=$ROS_PACKAGE_PATH:$px4_dir/Tools/simulation/gazebo/sitl_gazebo
+export GAZEBO_PLUGIN_PATH=$GAZEBO_PLUGIN_PATH:/usr/lib/x86_64-linux-gnu/gazebo-11/plugins
+```
+
+*Note*: The path for gazebo may vary for a different version of Gazebo, update `GAZEBO_PLUGIN_PATH` as well as `ROS_PACKAGE_PATH`
+accordingly.
+
+
+The default launch file can be run as the following command.
+```Bash
 roslaunch terrain_navigation_ros test_terrain_planner.launch
 ```
 


### PR DESCRIPTION
This PR addresses the issue highlighted in ETHZ fw repo https://github.com/ethz-asl/ethzasl_fw_px4/issues/57

I've added instructions specific to Ubuntu 20.04 + ROS Noetic + Gazebo Classic for anybody else trying to run `terrain_navigation`  with ROS1. 

@Jaeyoung-Lim @Ryanf55 