### PR TITLE
Port mav_planning_rviz plugins to ROS 2 Humble

### DIFF
--- a/mav_planning_rviz/CMakeLists.txt
+++ b/mav_planning_rviz/CMakeLists.txt
@@ -1,76 +1,153 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.14.4)
 project(mav_planning_rviz)
 
-find_package(catkin_simple REQUIRED)
-catkin_simple(ALL_DEPS_REQUIRED)
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
 
-add_definitions(-std=c++11)
+# Set policy for 3.16 for CMP0076 defaulting to ON
+cmake_policy(VERSION 3.16)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# Qt5 boilerplate options from http://doc.qt.io/qt-5/cmake-manual.html
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTOMOC ON)
 
 # These settings all stolen from visualization_tutorials:
 # This setting causes Qt's "MOC" generation to happen automatically.
-set(CMAKE_AUTOMOC OFF)
+# set(CMAKE_AUTOMOC OFF)
 
-set(HEADER_FILES_QT
+find_package(ament_cmake REQUIRED)
+find_package(grid_map_core REQUIRED)
+find_package(grid_map_ros REQUIRED)
+find_package(interactive_markers REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rviz_common REQUIRED)
+find_package(rviz_default_plugins REQUIRED)
+find_package(rviz_ogre_vendor REQUIRED)
+find_package(rviz_rendering REQUIRED)
+find_package(tf2 REQUIRED)
+
+find_package(mav_msgs REQUIRED)
+find_package(mavros_msgs REQUIRED)
+find_package(planner_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
+find_package(trajectory_msgs REQUIRED)
+find_package(visualization_msgs REQUIRED)
+
+find_package(Qt5 REQUIRED COMPONENTS Core Gui Widgets Test Concurrent)
+
+set(mav_planning_rviz_plugins_headers_to_moc
   include/mav_planning_rviz/pose_widget.h
   include/mav_planning_rviz/planning_panel.h
   include/mav_planning_rviz/edit_button.h
 )
 
-set(SRC_FILES
-  src/planning_panel.cpp
-  src/pose_widget.cpp
-  src/edit_button.cpp
-  src/planning_interactive_markers.cpp
-  src/goal_marker.cpp
-)
-
-# This plugin includes Qt widgets, so we must include Qt.
-# We'll use the version that rviz used so they are compatible.
-if(rviz_QT_VERSION VERSION_LESS "5")
-  message(STATUS "Using Qt4 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
-  find_package(Qt4 ${rviz_QT_VERSION} EXACT REQUIRED QtCore QtGui)
-  # pull in all required include dirs, define QT_LIBRARIES, etc.
-  include(${QT_USE_FILE})
-  qt4_wrap_cpp(MOC_FILES
-    ${HEADER_FILES_QT}
-  )
-else()
-  message(STATUS "Using Qt5 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
-  find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
-  # make target_link_libraries(${QT_LIBRARIES}) pull in all required dependencies
-  set(QT_LIBRARIES Qt5::Widgets)
-  QT5_WRAP_CPP(MOC_FILES
-    ${HEADER_FILES_QT}
-  )
-endif()
-# I prefer the Qt signals and slots to avoid defining "emit", "slots",
-# etc because they can conflict with boost signals, so define QT_NO_KEYWORDS here.
-add_definitions(-DQT_NO_KEYWORDS)
+# # I prefer the Qt signals and slots to avoid defining "emit", "slots",
+# # etc because they can conflict with boost signals, so define QT_NO_KEYWORDS here.
+# add_definitions(-DQT_NO_KEYWORDS)
 
 # In case someone else struggles with getting panels to build, see this
 # solution:
 # https://answers.ros.org/question/215487/could-not-load-panel-in-rviz-pluginlibfactory-the-plugin-for-class/
 
-#############
-# LIBRARIES #
-#############
-cs_add_library(${PROJECT_NAME}
-  ${SRC_FILES}
-  ${MOC_FILES}
+add_library(${PROJECT_NAME} SHARED
+  src/planning_panel.cpp
+  src/pose_widget.cpp
+  src/edit_button.cpp
+  src/planning_interactive_markers.cpp
+  src/goal_marker.cpp
+  ${mav_planning_rviz_plugins_headers_to_moc}
 )
-target_link_libraries(${PROJECT_NAME} ${QT_LIBRARIES})
 
-
-############
-# BINARIES #
-############
-cs_add_executable(standalone_test
-  src/standalone_test.cpp
+ament_target_dependencies(${PROJECT_NAME}
+  grid_map_core
+  grid_map_ros
+  interactive_markers
+  pluginlib
+  Qt5
+  rclcpp
+  rviz_common
+  rviz_default_plugins
+  rviz_ogre_vendor
+  rviz_rendering
 )
-target_link_libraries(standalone_test ${PROJECT_NAME})
 
-##########
-# EXPORT #
-##########
-cs_install()
-cs_export()
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+  ${Qt5Widgets_INCLUDE_DIRS}
+  ${OGRE_INCLUDE_DIRS}
+  ${mav_msgs_INCLUDE_DIRS}/..
+)
+
+target_link_libraries(${PROJECT_NAME}
+  ${mav_msgs_TARGETS}
+  ${mavros_msgs_TARGETS}
+  ${planner_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  ${std_srvs_TARGETS}
+  ${trajectory_msgs_TARGETS}
+  ${visualization_msgs_TARGETS}
+  rviz_common::rviz_common
+)
+
+# Causes the visibility macros to use dllexport rather than dllimport,
+# which is appropriate when building the dll but not consuming it.
+# TODO: Make this specific to this project (not rviz default plugins)
+target_compile_definitions(${PROJECT_NAME} PRIVATE "RVIZ_DEFAULT_PLUGINS_BUILDING_LIBRARY")
+
+pluginlib_export_plugin_description_file(rviz_common plugins_description.xml)
+
+# add_executable(standalone_test
+#   src/standalone_test.cpp
+# )
+
+# target_link_libraries(standalone_test PUBLIC
+#   ${PROJECT_NAME}
+# )
+
+# Install
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+)
+
+install(
+  TARGETS
+  ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_include_directories(include)
+ament_export_dependencies(
+  Qt5
+  rviz_common
+  geometry_msgs
+  rclcpp
+)
+
+# install(
+#   TARGETS
+#   standalone_test
+#   DESTINATION lib/${PROJECT_NAME}
+# )
+
+if(BUILD_TESTING)
+  # find_package(ament_lint_auto REQUIRED)
+  # ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/mav_planning_rviz/include/mav_planning_rviz/edit_button.h
+++ b/mav_planning_rviz/include/mav_planning_rviz/edit_button.h
@@ -2,7 +2,7 @@
 #define MAV_PLANNING_RVIZ_EDIT_BUTTON_H_
 
 #ifndef Q_MOC_RUN
-#include <mav_msgs/eigen_mav_msgs.h>
+#include <mav_msgs/eigen_mav_msgs.hpp>
 #include <QPushButton>
 #include <QWidget>
 #endif

--- a/mav_planning_rviz/include/mav_planning_rviz/goal_marker.h
+++ b/mav_planning_rviz/include/mav_planning_rviz/goal_marker.h
@@ -2,34 +2,37 @@
 #ifndef MAV_PLANNING_RVIZ_GOAL_MARKER_H_
 #define MAV_PLANNING_RVIZ_GOAL_MARKER_H_
 
-#include <ros/ros.h>
-#include <Eigen/Dense>
 #include <mutex>
 
-#include <grid_map_msgs/GridMap.h>
-#include <interactive_markers/interactive_marker_server.h>
-#include <visualization_msgs/InteractiveMarkerFeedback.h>
+#include <Eigen/Dense>
+#include <rclcpp/rclcpp.hpp>
+
+#include <grid_map_msgs/msg/grid_map.hpp>
+#include <interactive_markers/interactive_marker_server.hpp>
+#include <visualization_msgs/msg/interactive_marker_feedback.h>
 #include <grid_map_core/GridMap.hpp>
 #include <grid_map_ros/GridMapRosConverter.hpp>
+
 class GoalMarker {
  public:
-  GoalMarker(const ros::NodeHandle &nh);
+  GoalMarker(rclcpp::Node::SharedPtr node);
   virtual ~GoalMarker();
   Eigen::Vector3d getGoalPosition() { return goal_pos_; };
 
  private:
-  Eigen::Vector3d toEigen(const geometry_msgs::Pose &p) {
+  Eigen::Vector3d toEigen(const geometry_msgs::msg::Pose &p) {
     Eigen::Vector3d position(p.position.x, p.position.y, p.position.z);
     return position;
   }
-  void processSetPoseFeedback(const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback);
-  void GridmapCallback(const grid_map_msgs::GridMap &msg);
+  void processSetPoseFeedback(const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr &feedback);
+  void GridmapCallback(const grid_map_msgs::msg::GridMap &msg);
 
-  ros::NodeHandle nh_;
-  ros::Subscriber grid_map_sub_;
-  ros::ServiceClient goal_serviceclient_;
+  rclcpp::Node::SharedPtr node_;
+  rclcpp::Subscription<grid_map_msgs::msg::GridMap>::SharedPtr grid_map_sub_;
+  // rclcpp::Client<>::SharedPtr goal_serviceclient_;
+
   interactive_markers::InteractiveMarkerServer marker_server_;
-  visualization_msgs::InteractiveMarker set_goal_marker_;
+  visualization_msgs::msg::InteractiveMarker set_goal_marker_;
 
   Eigen::Vector3d goal_pos_{Eigen::Vector3d::Zero()};
   grid_map::GridMap map_;

--- a/mav_planning_rviz/include/mav_planning_rviz/planning_interactive_markers.h
+++ b/mav_planning_rviz/include/mav_planning_rviz/planning_interactive_markers.h
@@ -3,10 +3,11 @@
 
 #include <functional>
 
-#include <interactive_markers/interactive_marker_server.h>
-#include <mav_msgs/conversions.h>
-#include <mav_msgs/eigen_mav_msgs.h>
-#include <ros/ros.h>
+#include <interactive_markers/interactive_marker_server.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <mav_msgs/conversions.hpp>
+#include <mav_msgs/eigen_mav_msgs.hpp>
 
 namespace mav_planning_rviz {
 
@@ -14,8 +15,9 @@ class PlanningInteractiveMarkers {
  public:
   typedef std::function<void(const mav_msgs::EigenTrajectoryPoint& pose)> PoseUpdatedFunctionType;
 
-  PlanningInteractiveMarkers(const ros::NodeHandle& nh);
-  ~PlanningInteractiveMarkers() {}
+  PlanningInteractiveMarkers(rclcpp::Node::SharedPtr node);
+
+  ~PlanningInteractiveMarkers();
 
   void setFrameId(const std::string& frame_id);
   // Bind callback for whenever pose updates.
@@ -34,14 +36,14 @@ class PlanningInteractiveMarkers {
   void updateMarkerPose(const std::string& id, const mav_msgs::EigenTrajectoryPoint& pose);
   void disableMarker(const std::string& id);
 
-  void processSetPoseFeedback(const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback);
+  void processSetPoseFeedback(const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr& feedback);
 
  private:
   // Creates markers without adding them to the marker server.
   void createMarkers();
 
   // ROS stuff.
-  ros::NodeHandle nh_;
+  rclcpp::Node::SharedPtr node_;
   interactive_markers::InteractiveMarkerServer marker_server_;
 
   // Settings.
@@ -49,12 +51,12 @@ class PlanningInteractiveMarkers {
 
   // State.
   bool initialized_;
-  visualization_msgs::InteractiveMarker set_pose_marker_;
+  visualization_msgs::msg::InteractiveMarker set_pose_marker_;
 
   // This is map for waypoint visualization markers:
-  std::map<std::string, visualization_msgs::InteractiveMarker> marker_map_;
+  std::map<std::string, visualization_msgs::msg::InteractiveMarker> marker_map_;
   // This determines how the markers in the marker map will look:
-  visualization_msgs::InteractiveMarker marker_prototype_;
+  visualization_msgs::msg::InteractiveMarker marker_prototype_;
 
   // State:
   PoseUpdatedFunctionType pose_updated_function_;

--- a/mav_planning_rviz/include/mav_planning_rviz/planning_panel.h
+++ b/mav_planning_rviz/include/mav_planning_rviz/planning_panel.h
@@ -2,15 +2,17 @@
 #define MAV_PLANNING_RVIZ_PLANNING_PANEL_H_
 
 #ifndef Q_MOC_RUN
-#include <nav_msgs/Odometry.h>
-#include <ros/ros.h>
-#include <rviz/panel.h>
+#include <nav_msgs/msg/odometry.hpp>
+#include <planner_msgs/msg/navigation_status.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <rviz_common/panel.hpp>
+
 #include <QGroupBox>
 #include "mav_planning_rviz/edit_button.h"
 #include "mav_planning_rviz/goal_marker.h"
 #include "mav_planning_rviz/planning_interactive_markers.h"
 #include "mav_planning_rviz/pose_widget.h"
-#include "planner_msgs/NavigationStatus.h"
 #endif
 
 enum PLANNER_STATE { HOLD = 1, NAVIGATE = 2, ROLLOUT = 3, ABORT = 4, RETURN = 5 };
@@ -19,7 +21,7 @@ class QLineEdit;
 class QCheckBox;
 namespace mav_planning_rviz {
 
-class PlanningPanel : public rviz::Panel {
+class PlanningPanel : public rviz_common::Panel {
   // This class uses Qt slots and is a subclass of QObject, so it needs
   // the Q_OBJECT macro.
   Q_OBJECT
@@ -36,8 +38,8 @@ class PlanningPanel : public rviz::Panel {
   // Now we declare overrides of rviz::Panel functions for saving and
   // loading data from the config file.  Here the data is the
   // topic name.
-  virtual void load(const rviz::Config& config);
-  virtual void save(rviz::Config config) const;
+  virtual void load(const rviz_common::Config& config);
+  virtual void save(rviz_common::Config config) const;
   virtual void onInitialize();
 
   // All the settings to manage pose <-> edit mapping.
@@ -47,9 +49,9 @@ class PlanningPanel : public rviz::Panel {
   // Callback from ROS when the pose updates:
   void updateInteractiveMarkerPose(const mav_msgs::EigenTrajectoryPoint& pose);
   // And when we get robot odometry:
-  void odometryCallback(const nav_msgs::Odometry& msg);
+  void odometryCallback(const nav_msgs::msg::Odometry& msg);
 
-  void plannerstateCallback(const planner_msgs::NavigationStatus& msg);
+  void plannerstateCallback(const planner_msgs::msg::NavigationStatus& msg);
 
   // Next come a couple of public Qt slots.
  public Q_SLOTS:
@@ -90,11 +92,11 @@ class PlanningPanel : public rviz::Panel {
   QGroupBox* createTerrainLoaderGroup();
 
   // ROS Stuff:
-  ros::NodeHandle nh_;
-  ros::Publisher waypoint_pub_;
-  ros::Publisher controller_pub_;
-  ros::Subscriber odometry_sub_;
-  ros::Subscriber planner_state_sub_;
+  rclcpp::Node::SharedPtr node_;
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr waypoint_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr controller_pub_;
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odometry_sub_;
+  rclcpp::Subscription<planner_msgs::msg::NavigationStatus>::SharedPtr planner_state_sub_;
 
   std::shared_ptr<GoalMarker> goal_marker_;
 

--- a/mav_planning_rviz/include/mav_planning_rviz/pose_widget.h
+++ b/mav_planning_rviz/include/mav_planning_rviz/pose_widget.h
@@ -2,7 +2,7 @@
 #define MAV_PLANNING_RVIZ_POSE_WIDGET_H_
 
 #ifndef Q_MOC_RUN
-#include <mav_msgs/eigen_mav_msgs.h>
+#include <mav_msgs/eigen_mav_msgs.hpp>
 #include <QItemDelegate>
 #include <QLineEdit>
 #include <QStringList>

--- a/mav_planning_rviz/package.xml
+++ b/mav_planning_rviz/package.xml
@@ -1,33 +1,41 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>mav_planning_rviz</name>
   <version>0.0.0</version>
-  <description>
-    Planning plugin for RVIZ.
-  </description>
-
+  <description>Planning plugin for RVIZ.</description>
   <author email="helen.oleynikova@mavt.ethz.ch">Helen Oleynikova</author>
-
   <maintainer email="helen.oleynikova@mavt.ethz.ch">Helen Oleynikova</maintainer>
-
   <license>BSD</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
-  <buildtool_depend>catkin_simple</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>qtbase5-dev</build_depend>
 
-  <depend>mav_msgs</depend>
-  <depend>roscpp</depend>
-  <depend>std_msgs</depend>
-  <depend>tf</depend>
-  <depend>visualization_msgs</depend>
-  <depend>mavros_msgs</depend>
-  <depend>planner_msgs</depend>
   <depend>grid_map_core</depend>
   <depend>grid_map_ros</depend>
-  <depend>rviz</depend>
+  <depend>interactive_markers</depend>
+  <depend>rclcpp</depend>
+  <depend>rviz_common</depend>
+  <depend>rviz_default_plugins</depend>
+  <depend>rviz_ogre_vendor</depend>
+  <depend>rviz_rendering</depend>
+  <depend>tf2</depend>
 
+  <depend>mav_msgs</depend>
+  <depend>mavros_msgs</depend>
+  <depend>planner_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
+  <depend>trajectory_msgs</depend>
+  <depend>visualization_msgs</depend>
+
+  <exec_depend>libqt5-core</exec_depend>
+  <exec_depend>libqt5-gui</exec_depend>
+  <exec_depend>libqt5-opengl</exec_depend>
+  <exec_depend>libqt5-widgets</exec_depend>
 
   <export>
-      <rviz plugin="${prefix}/plugin_description.xml"/>
+    <build_type>ament_cmake</build_type>
+    <!-- <rviz plugin="${prefix}/plugin_description.xml"/> -->
   </export>
 </package>

--- a/mav_planning_rviz/plugin_description.xml
+++ b/mav_planning_rviz/plugin_description.xml
@@ -1,9 +1,0 @@
-<library path="libmav_planning_rviz">
-  <class name="mav_planning_rviz/PlanningPanel"
-         type="mav_planning_rviz::PlanningPanel"
-         base_class_type="rviz::Panel">
-    <description>
-      A panel that allows easy control for MAV pathplanning.
-    </description>
-  </class>
-</library>

--- a/mav_planning_rviz/plugins_description.xml
+++ b/mav_planning_rviz/plugins_description.xml
@@ -1,0 +1,11 @@
+<library path="mav_planning_rviz">
+
+  <class name="mav_planning_rviz/PlanningPanel"
+         type="mav_planning_rviz::PlanningPanel"
+         base_class_type="rviz_common::Panel">
+    <description>
+      A panel that allows easy control for MAV path planning.
+    </description>
+  </class>
+
+`</library>

--- a/mav_planning_rviz/src/goal_marker.cpp
+++ b/mav_planning_rviz/src/goal_marker.cpp
@@ -1,36 +1,43 @@
 #include "mav_planning_rviz/goal_marker.h"
+#include <functional>
 
-GoalMarker::GoalMarker(const ros::NodeHandle &nh) : nh_(nh), marker_server_("goal") {
+using std::placeholders::_1;
+
+GoalMarker::GoalMarker(rclcpp::Node::SharedPtr node)
+  : node_(node), marker_server_("goal", node) {
   set_goal_marker_.header.frame_id = "map";
   set_goal_marker_.name = "set_pose";
   set_goal_marker_.scale = 100.0;
   set_goal_marker_.controls.clear();
 
-  constexpr double kSqrt2Over2 = sqrt(2.0) / 2.0;
+  const double kSqrt2Over2 = sqrt(2.0) / 2.0;
 
   // Set up controls: x, y, z, and yaw.
-  visualization_msgs::InteractiveMarkerControl control;
+  visualization_msgs::msg::InteractiveMarkerControl control;
   set_goal_marker_.controls.clear();
   control.orientation.w = kSqrt2Over2;
   control.orientation.x = 0;
   control.orientation.y = kSqrt2Over2;
   control.orientation.z = 0;
-  control.interaction_mode = visualization_msgs::InteractiveMarkerControl::MOVE_PLANE;
+  control.interaction_mode = visualization_msgs::msg::InteractiveMarkerControl::MOVE_PLANE;
   control.name = "move plane";
   set_goal_marker_.controls.push_back(control);
 
   marker_server_.insert(set_goal_marker_);
-  marker_server_.setCallback(set_goal_marker_.name, boost::bind(&GoalMarker::processSetPoseFeedback, this, _1));
+  marker_server_.setCallback(set_goal_marker_.name,
+      std::bind(&GoalMarker::processSetPoseFeedback, this, _1));
   marker_server_.applyChanges();
-  grid_map_sub_ = nh_.subscribe("/grid_map", 1, &GoalMarker::GridmapCallback, this, ros::TransportHints().tcpNoDelay());
+  grid_map_sub_ = node_->create_subscription<grid_map_msgs::msg::GridMap>(
+      "/grid_map", 1,
+      std::bind(&GoalMarker::GridmapCallback, this, _1));
 }
 
-GoalMarker::~GoalMarker() {}
+GoalMarker::~GoalMarker() = default;
 
-void GoalMarker::processSetPoseFeedback(const visualization_msgs::InteractiveMarkerFeedbackConstPtr &feedback) {
+void GoalMarker::processSetPoseFeedback(const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr &feedback) {
   const std::lock_guard<std::mutex> lock(goal_mutex_);
   // TODO: Set goal position from menu
-  if (feedback->event_type == visualization_msgs::InteractiveMarkerFeedback::POSE_UPDATE) {
+  if (feedback->event_type == visualization_msgs::msg::InteractiveMarkerFeedback::POSE_UPDATE) {
     set_goal_marker_.pose = feedback->pose;
     Eigen::Vector2d marker_position_2d(set_goal_marker_.pose.position.x, set_goal_marker_.pose.position.y);
     if (map_.isInside(marker_position_2d)) {
@@ -44,7 +51,7 @@ void GoalMarker::processSetPoseFeedback(const visualization_msgs::InteractiveMar
   marker_server_.applyChanges();
 }
 
-void GoalMarker::GridmapCallback(const grid_map_msgs::GridMap &msg) {
+void GoalMarker::GridmapCallback(const grid_map_msgs::msg::GridMap &msg) {
   const std::lock_guard<std::mutex> lock(goal_mutex_);
   grid_map::GridMapRosConverter::fromMessage(msg, map_);
   Eigen::Vector2d marker_position_2d(set_goal_marker_.pose.position.x, set_goal_marker_.pose.position.y);

--- a/terrain_navigation_ros/launch/test_terrain_planner.launch.py
+++ b/terrain_navigation_ros/launch/test_terrain_planner.launch.py
@@ -1,0 +1,128 @@
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchContext
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.actions import ExecuteProcess
+from launch.actions import OpaqueFunction
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration
+
+from launch_ros.actions import Node
+
+
+def generate_terrain_navigation_action(
+    context: LaunchContext, *args, **kwargs
+) -> [ExecuteProcess]:
+    """Generate the terrain_navigation_ros launch action."""
+
+    pkg_terrain_navigation_ros = get_package_share_directory("terrain_navigation_ros")
+
+    # arguments.
+    location = LaunchConfiguration("location").perform(context)
+
+    # terrain navigation node
+    terrain_path = os.path.join(
+        pkg_terrain_navigation_ros,
+        "../resources",
+        location + ".tf",
+    )
+    terrain_color_path = os.path.join(
+        pkg_terrain_navigation_ros,
+        "../resources",
+        location + "_color.tf",
+    )
+    resource_path = os.path.join(pkg_terrain_navigation_ros, "../resources")
+
+    # debug - check the context is resolved correctly.
+    # print(f"terrain_path:       {terrain_path}")
+    # print(f"terrain_color_path: {terrain_color_path}")
+    # print(f"resource_path:      {resource_path}")
+
+    # Create action.
+    node = Node(
+        package="terrain_navigation_ros",
+        executable="terrain_planner_node",
+        name="terrain_planner",
+        parameters=[
+            {"terrain_path": terrain_path},
+            {"terrain_color_path": terrain_color_path},
+            {"resource_path": resource_path},
+            {"minimum_turn_radius": "80.0"},
+        ],
+        output="screen",
+    )
+    return [node]
+
+
+def generate_launch_description():
+    """Generate a launch description."""
+
+    pkg_terrain_planner = get_package_share_directory("terrain_planner")
+
+    # mavros node
+    # TODO include launch description 
+
+    # px4 posix_sitl node
+    # TODO include launch description 
+
+    # terrain navigation node
+    terrain_navigation = OpaqueFunction(function=generate_terrain_navigation_action)
+
+    # rviz node
+    rviz = Node(
+        package="rviz2",
+        executable="rviz2",
+        arguments=["-d", os.path.join(pkg_terrain_planner, "launch", "config.rviz")],
+        condition=IfCondition(LaunchConfiguration("rviz")),
+    )
+
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "mav_name", default_value="tiltrotor", description="Vehicle name."
+            ),
+            DeclareLaunchArgument(
+                "fcu_url",
+                default_value="udp://:14540@127.0.0.1:14557",
+                description="Flight controller address.",
+            ),
+            DeclareLaunchArgument(
+                "gcs_url",
+                default_value="",
+                description="Ground control station address.",
+            ),
+            DeclareLaunchArgument("tgt_system", default_value="1", description=""),
+            DeclareLaunchArgument("tgt_component", default_value="1", description=""),
+            DeclareLaunchArgument("command_input", default_value="2", description=""),
+            DeclareLaunchArgument(
+                "gazebo_simulation", default_value="true", description="Run Gazebo."
+            ),
+            DeclareLaunchArgument(
+                "log_output",
+                default_value="screen",
+                description="Location to log output.",
+            ),
+            DeclareLaunchArgument(
+                "fcu_protocol",
+                default_value="v2.0",
+                description="Flight controller protocol version.",
+            ),
+            DeclareLaunchArgument(
+                "respawn_mavros", default_value="false", description="Respawn mavros."
+            ),
+            DeclareLaunchArgument(
+                "rviz", default_value="true", description="Open RViz."
+            ),
+            DeclareLaunchArgument(
+                "location", default_value="davosdorf", description="Location."
+            ),
+            DeclareLaunchArgument(
+                "gui", default_value="false", description="Open SITL GUI."
+            ),
+            terrain_navigation,
+            rviz,
+        ]
+    )


### PR DESCRIPTION
Follow-up to https://github.com/ethz-asl/terrain-navigation/pull/20. This updates the mav_planning_rviz plugins for ROS 2.

This version builds and runs, however there are currently issues with the interactive markers to resolve and a test environment running on a ROS 2 supported version of PX4 or ArduPilot is required (either using mavros for ROS 2 or preferably with DDS integration).

### Dependencies

- https://github.com/ethz-asl/terrain-navigation/pull/20

### Tasks

- Requires rebase when #20 is merged.
