### PR TITLE
Pin grid_map_geo dependency to ROS1 based master branch commit

### DIFF
--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -1,5 +1,5 @@
-- git: {local-name: catkin_simple, uri: 'https://github.com/catkin/catkin_simple'} 
-- git: {local-name: eigen_catkin, uri: 'https://github.com/ethz-asl/eigen_catkin'}
+- git: {local-name: catkin_simple, uri: 'https://github.com/catkin/catkin_simple', version: master}
+- git: {local-name: eigen_catkin, uri: 'https://github.com/ethz-asl/eigen_catkin', version: master}
 - git: {local-name: grid_map, uri: 'https://github.com/Jaeyoung-Lim/grid_map.git', version: master}
 - git: {local-name: grid_map_geo, uri: 'https://github.com/ethz-asl/grid_map_geo.git', version: master}
-- git: {local-name: mav_comm, uri: 'https://github.com/ethz-asl/mav_comm.git'}
+- git: {local-name: mav_comm, uri: 'https://github.com/ethz-asl/mav_comm.git', version: master}

--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -1,5 +1,5 @@
 - git: {local-name: catkin_simple, uri: 'https://github.com/catkin/catkin_simple'} 
 - git: {local-name: eigen_catkin, uri: 'https://github.com/ethz-asl/eigen_catkin'}
-- git: {local-name: grid_map, uri: 'https://github.com/Jaeyoung-Lim/grid_map.git', version: c45c300ce3930312dcb4deadc811ccb4eaeb4bd0}
-- git: {local-name: grid_map_geo, uri: 'https://github.com/ethz-asl/grid_map_geo.git', branch: master}
+- git: {local-name: grid_map, uri: 'https://github.com/Jaeyoung-Lim/grid_map.git', version: master}
+- git: {local-name: grid_map_geo, uri: 'https://github.com/ethz-asl/grid_map_geo.git', version: master}
 - git: {local-name: mav_comm, uri: 'https://github.com/ethz-asl/mav_comm.git'}

--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -1,5 +1,5 @@
 - git: {local-name: catkin_simple, uri: 'https://github.com/catkin/catkin_simple'} 
 - git: {local-name: eigen_catkin, uri: 'https://github.com/ethz-asl/eigen_catkin'}
 - git: {local-name: grid_map, uri: 'https://github.com/Jaeyoung-Lim/grid_map.git', version: c45c300ce3930312dcb4deadc811ccb4eaeb4bd0}
-- git: {local-name: grid_map_geo, uri: 'https://github.com/ethz-asl/grid_map_geo.git', version: 64161b8d30b083f362052411e2ca0d6f494bfac3}
+- git: {local-name: grid_map_geo, uri: 'https://github.com/ethz-asl/grid_map_geo.git', branch: master}
 - git: {local-name: mav_comm, uri: 'https://github.com/ethz-asl/mav_comm.git'}

--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -1,5 +1,5 @@
 - git: {local-name: catkin_simple, uri: 'https://github.com/catkin/catkin_simple'} 
 - git: {local-name: eigen_catkin, uri: 'https://github.com/ethz-asl/eigen_catkin'}
 - git: {local-name: grid_map, uri: 'https://github.com/Jaeyoung-Lim/grid_map.git', version: c45c300ce3930312dcb4deadc811ccb4eaeb4bd0}
-- git: {local-name: grid_map_geo, uri: 'https://github.com/ethz-asl/grid_map_geo.git'}
+- git: {local-name: grid_map_geo, uri: 'https://github.com/ethz-asl/grid_map_geo.git', version: 64161b8d30b083f362052411e2ca0d6f494bfac3}
 - git: {local-name: mav_comm, uri: 'https://github.com/ethz-asl/mav_comm.git'}


### PR DESCRIPTION
I faced build issues while trying to build the Dockerfile for ROS1 related to `yaml_cpp_vendor` which looks like a ROS2 dependency of `grid_map_geo`. I am able to build successfully by pinning `grid_map_geo` to the `master` branch commit ( has: 64161b8d30b083f362052411e2ca0d6f494bfac3) inside the `dependencies.rosinstall` which is ROS1 as opposed to letting it pick the default branch which is `ros2`.

Error logs:

```Bash
 => [all-deps 1/4] COPY dependencies.rosinstall src/terrain-navigation/dependencies.rosinstall                                0.0s
 => [all-deps 2/4] RUN wstool init src src/terrain-navigation/dependencies.rosinstall                                         6.2s
 => [all-deps 3/4] RUN wstool update -t src -j4                                                                               2.1s 
 => ERROR [all-deps 4/4] RUN apt-get update     && rosdep update     && source /opt/ros/noetic/setup.bash     && rosdep ins  21.5s 
------                                                                                                                             
 > [all-deps 4/4] RUN apt-get update     && rosdep update     && source /opt/ros/noetic/setup.bash     && rosdep install --from-paths src --ignore-src -y     && rm -rf /var/lib/apt/lists/*:                                                                         
0.647 Get:1 http://archive.ubuntu.com/ubuntu focal InRelease [265 kB]                                                              
0.811 Get:2 http://security.ubuntu.com/ubuntu focal-security InRelease [114 kB]                                                    
0.837 Get:3 http://packages.ros.org/ros/ubuntu focal InRelease [4679 B]                                                            
1.141 Get:4 http://packages.ros.org/ros/ubuntu focal/main amd64 Packages [798 kB]
1.489 Get:5 http://archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
1.679 Get:6 http://archive.ubuntu.com/ubuntu focal-backports InRelease [108 kB]
1.794 Get:7 http://security.ubuntu.com/ubuntu focal-security/restricted amd64 Packages [3057 kB]
1.869 Get:8 http://archive.ubuntu.com/ubuntu focal/multiverse amd64 Packages [177 kB]
1.953 Get:9 http://archive.ubuntu.com/ubuntu focal/universe amd64 Packages [11.3 MB]
3.258 Get:10 http://archive.ubuntu.com/ubuntu focal/main amd64 Packages [1275 kB]
3.312 Get:11 http://security.ubuntu.com/ubuntu focal-security/universe amd64 Packages [1130 kB]
3.376 Get:12 http://security.ubuntu.com/ubuntu focal-security/multiverse amd64 Packages [29.3 kB]
3.379 Get:13 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages [3221 kB]
3.381 Get:14 http://archive.ubuntu.com/ubuntu focal/restricted amd64 Packages [33.4 kB]
3.385 Get:15 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 Packages [32.0 kB]
3.387 Get:16 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [1435 kB]
3.540 Get:17 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [3712 kB]
3.902 Get:18 http://archive.ubuntu.com/ubuntu focal-updates/restricted amd64 Packages [3212 kB]
4.587 Get:19 http://archive.ubuntu.com/ubuntu focal-backports/universe amd64 Packages [28.6 kB]
4.938 Get:20 http://archive.ubuntu.com/ubuntu focal-backports/main amd64 Packages [55.2 kB]
6.088 Fetched 30.1 MB in 6s (5251 kB/s)
6.088 Reading package lists...
19.84 Warning: running 'rosdep update' as root is not recommended.
19.84   You should run 'sudo rosdep fix-permissions' and invoke 'rosdep update' again without sudo.
19.84 reading in sources list data from /etc/ros/rosdep/sources.list.d
19.84 Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/osx-homebrew.yaml
19.84 Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/base.yaml
19.84 Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/python.yaml
19.84 Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/ruby.yaml
19.84 Hit https://raw.githubusercontent.com/ros/rosdistro/master/releases/fuerte.yaml
19.84 Query rosdistro index https://raw.githubusercontent.com/ros/rosdistro/master/index-v4.yaml
19.84 Skip end-of-life distro "ardent"
19.84 Skip end-of-life distro "bouncy"
19.84 Skip end-of-life distro "crystal"
19.84 Skip end-of-life distro "dashing"
19.84 Skip end-of-life distro "eloquent"
19.84 Skip end-of-life distro "foxy"
19.84 Skip end-of-life distro "galactic"
19.84 Skip end-of-life distro "groovy"
19.84 Add distro "humble"
19.84 Skip end-of-life distro "hydro"
19.84 Skip end-of-life distro "indigo"
19.84 Add distro "iron"
19.84 Skip end-of-life distro "jade"
19.84 Skip end-of-life distro "kinetic"
19.84 Skip end-of-life distro "lunar"
19.84 Skip end-of-life distro "melodic"
19.84 Add distro "noetic"
19.84 Add distro "rolling"
19.84 updated cache in /root/.ros/rosdep/sources.cache
21.31 ERROR: the following packages/stacks could not have their rosdep keys resolved
21.31 to system dependencies:
21.31 grid_map_geo: Cannot locate rosdep definition for [yaml_cpp_vendor]
------
Dockerfile:40
--------------------
  39 |     
  40 | >>> RUN apt-get update \
  41 | >>>     && rosdep update \
  42 | >>>     && source /opt/ros/noetic/setup.bash \
  43 | >>>     && rosdep install --from-paths src --ignore-src -y \
  44 | >>>     && rm -rf /var/lib/apt/lists/*
  45 |     
--------------------
ERROR: failed to solve: process "/bin/bash -c apt-get update     && rosdep update     && source /opt/ros/noetic/setup.bash     && rosdep install --from-paths src --ignore-src -y     && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 1

```


Successful build logs after pinning `grid_map_geo` :

```Bash
docker build --file docker/Dockerfile --tag terrain-navigation-ros1 .
[+] Building 615.4s (19/19) FINISHED                                                                                docker:default
 => [internal] load build definition from Dockerfile                                                                          0.0s
 => => transferring dockerfile: 1.71kB                                                                                        0.0s
 => [internal] load .dockerignore                                                                                             0.0s
 => => transferring context: 2B                                                                                               0.0s
 => [internal] load metadata for docker.io/library/ros:noetic-ros-core-focal                                                  0.8s
 => [repo-deps  1/10] FROM docker.io/library/ros:noetic-ros-core-focal@sha256:933f0c8fc50fc1177617c615e7bed36c93ef038c08ff60  0.0s
 => [internal] load build context                                                                                             0.0s
 => => transferring context: 1.10kB                                                                                           0.0s
 => CACHED [repo-deps  2/10] WORKDIR /root/catkin_ws/src/terrain-navigation                                                   0.0s
 => CACHED [repo-deps  3/10] COPY mav_planning_rviz/package.xml mav_planning_rviz/package.xml                                 0.0s
 => CACHED [repo-deps  4/10] COPY planner_msgs/package.xml planner_msgs/package.xml                                           0.0s
 => CACHED [repo-deps  5/10] COPY terrain_navigation/package.xml terrain_navigation/package.xml                               0.0s
 => CACHED [repo-deps  6/10] COPY terrain_navigation_ros/package.xml terrain_navigation_ros/package.xml                       0.0s
 => CACHED [repo-deps  7/10] COPY terrain_planner/package.xml terrain_planner/package.xml                                     0.0s
 => CACHED [repo-deps  8/10] COPY terrain_planner_benchmark/package.xml terrain_planner_benchmark/package.xml                 0.0s
 => CACHED [repo-deps  9/10] WORKDIR /root/catkin_ws/                                                                         0.0s
 => [repo-deps 10/10] RUN apt-get update     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends   554.1s
 => [all-deps 1/4] COPY dependencies.rosinstall src/terrain-navigation/dependencies.rosinstall                                0.0s
 => [all-deps 2/4] RUN wstool init src src/terrain-navigation/dependencies.rosinstall                                         7.3s
 => [all-deps 3/4] RUN wstool update -t src -j4                                                                               2.1s 
 => [all-deps 4/4] RUN apt-get update     && rosdep update     && source /opt/ros/noetic/setup.bash     && rosdep install -  35.8s 
 => exporting to image                                                                                                       15.1s 
 => => exporting layers                                                                                                      15.1s 
 => => writing image sha256:312aebd4a41a12821dcbce09ded35d75d539a396b98bc46c2e17db4bf9221ef2                                  0.0s 
 => => naming to docker.io/library/terrain-navigation-ros1  
```


For reference, I tested this on an Ubuntu 20.04 machine Docker version 24.0.6, build ed223bc




