### PR TITLE
Update dockerfile and README for ROS 2 and latest tooling

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,21 @@
+---
+name: Build docker/Dockerfile
+on:
+  push:
+    branches:
+      - 'ros2'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build:
+    runs-on: [ubuntu-22.04]
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build the Dockerfile
+        run: |
+          docker build --file docker/Dockerfile --tag terrain-navigation-ros2 .
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -15,33 +15,27 @@ The implementation includes a global planner based on a RRT* in the Dubins Airpl
 
 ### Setting up the Build Environment using Docker
 
-If your operating system doesn't support ROS 1 noetic, docker is a great alternative. 
+If your operating system doesn't support ROS 2 humble, docker is a great alternative. 
 
 First, create the image, with the build context at the root of this repo
 
 ```Bash
-docker build --file docker/Dockerfile --tag terrain-navigation-ros1 .
+docker build --file docker/Dockerfile --tag terrain-navigation-ros2 .
 ```
 
 You can see the image exists:
 ```Bash
 docker images
 >>> REPOSITORY                TAG       IMAGE ID       CREATED        SIZE
->>> terrain-navigation-ros1   latest    5565f845ab4f   2 weeks ago    774MB
+>>> terrain-navigation-ros2   latest    5565f845ab4f   2 weeks ago    774MB
 ```
 
 Next, run the image, mounting in the source into a workspace. All the dependencies are now installed.
 ```Bash
-docker run --network=host -it -v $(pwd):/root/catkin_ws/src/terrain-navigation -w /root/catkin_ws terrain-navigation-ros1 bash
+docker run --network=host -it -v $(pwd):/root/ros2_ws/src/ethz-asl/terrain-navigation -w /root/ros2_ws terrain-navigation-ros2 bash
 ```
 
 ### Running the Build
-
-Configure the catkin workspace
-```Bash
-catkin config --extend "/opt/ros/noetic"
-catkin config --merge-devel
-```
 
 For dependencies that do not have binaries available, pull them into your ROS workspace using vcs.
 ```Bash
@@ -96,7 +90,7 @@ accordingly.
 
 The default launch file can be run as the following command.
 ```Bash
-roslaunch terrain_navigation_ros test_terrain_planner.launch
+ros2 launch terrain_navigation_ros test_terrain_planner.launch.py
 ```
 
 You can use [QGroundcontrol](http://qgroundcontrol.com/) to configure and fly the vehicle. Get the vehicle flying, and plan a mission to fly!

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,10 @@
-# https://github.com/osrf/docker_images/blob/df19ab7d5993d3b78a908362cdcd1479a8e78b35/ros/noetic/ubuntu/focal/ros-core/Dockerfile
-FROM ros:noetic-ros-core-focal as repo-deps
+# https://github.com/osrf/docker_images/blob/27cc0b68263bbbb10bb58dd814efc0a6b0a01ec7/ros/humble/ubuntu/jammy/ros-core/Dockerfile
+FROM ros:humble-ros-core-jammy as repo-deps
 # This layer installs basic tools and the direct dependencies of terrain-navigation.
 
 SHELL ["/bin/bash", "-c"]
 
-WORKDIR /root/catkin_ws/src/terrain-navigation
+WORKDIR /root/ros2_ws/src/ethz-asl/terrain-navigation
 
 COPY mav_planning_rviz/package.xml mav_planning_rviz/package.xml
 COPY planner_msgs/package.xml planner_msgs/package.xml
@@ -13,32 +13,42 @@ COPY terrain_navigation_ros/package.xml terrain_navigation_ros/package.xml
 COPY terrain_planner/package.xml terrain_planner/package.xml
 COPY terrain_planner_benchmark/package.xml terrain_planner_benchmark/package.xml
 
-WORKDIR /root/catkin_ws/
+WORKDIR /root/ros2_ws/
 
 RUN apt-get update \
     # https://ros.org/reps/rep-2001.html#dev-tools
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ros-dev-tools \
-        ros-noetic-catkin \
-        python3-catkin-tools \
         python3-pip \
+        python3-colcon-mixin \
+    && colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml \
+    && colcon mixin update default \
     && rosdep init \
     && rosdep update \
     && DEBIAN_FRONTEND=noninteractive rosdep install --from-paths src --ignore-src -r -y \
-    && python3 -m pip install \
-        wstool \
     && rm -rf /var/lib/apt/lists/*
 
 
 FROM repo-deps as all-deps
 # This layer installs dependencies of the other source packages.
 
-COPY dependencies.rosinstall src/terrain-navigation/dependencies.rosinstall
-RUN wstool init src src/terrain-navigation/dependencies.rosinstall
-RUN wstool update -t src -j4
+COPY terrain-navigation.repos src/ethz-asl/terrain-navigation/terrain-navigation.repos
 
+WORKDIR /root/ros2_ws/src
+RUN vcs import --recursive --debug --skip-existing < ethz-asl/terrain-navigation/terrain-navigation.repos
+
+WORKDIR /root/ros2_ws/
 RUN apt-get update \
     && rosdep update \
-    && source /opt/ros/noetic/setup.bash \
-    && rosdep install --from-paths src --ignore-src -y \
+    && source /opt/ros/humble/setup.bash \
+    && rosdep install --from-paths src --ignore-src -r -y \
     && rm -rf /var/lib/apt/lists/*
+
+FROM all-deps as build
+
+WORKDIR /root/ros2_ws/src/ethz-asl/terrain-navigation
+COPY . .
+WORKDIR /root/ros2_ws/
+
+RUN source /opt/ros/humble/setup.bash \
+    && colcon build --mixin release


### PR DESCRIPTION
This updates the supplied dockerfile to build in the ROS 2 environment. It can be used a base for developers that do not have Ubuntu 22 base OS. I also added a job in CI to test it works which will prevent regressions.

The README also needed a few updates that were missing.

CI was already building in docker, but it didn't use this dockerfile.

Relates to https://github.com/ethz-asl/terrain-navigation/issues/6