### PR TITLE
Switch back to upstream  grid_map

### DIFF
--- a/terrain-navigation.repos
+++ b/terrain-navigation.repos
@@ -1,8 +1,8 @@
 repositories:
-  ryanf55/grid_map:
+  ANYbotics/grid_map:
     type: git
-    url: https://github.com/ryanf55/grid_map.git
-    version: bugfix-403-cmake
+    url: https://github.com/ANYbotics/grid_map.git
+    version: humble
   ethz-asl/grid_map_geo:
     type: git
     url: https://github.com/ethz-asl/grid_map_geo.git


### PR DESCRIPTION
The cmake improvements have merged, so CI should be healthy again after this fix. Soon, we can stop compiling a ton of stuff from source and instead build against binaries.