### PR TITLE
Remove compiler warnings

### DIFF
--- a/terrain_navigation/include/terrain_navigation/path.h
+++ b/terrain_navigation/include/terrain_navigation/path.h
@@ -84,10 +84,9 @@ class Path {
    * @param closest_point
    * @param tangent
    * @param curvature
-   * @param epsilon
    */
   void getClosestPoint(const Eigen::Vector3d &position, Eigen::Vector3d &closest_point, Eigen::Vector3d &tangent,
-                       double &curvature, double epsilon = 0.001) {
+                       double &curvature) {
     closest_point = segments.front().states.front().position;
 
     // Iterate through all segments
@@ -121,7 +120,6 @@ class Path {
   }
 
   PathSegment &getCurrentSegment(const Eigen::Vector3d &position) {
-    double theta{-std::numeric_limits<double>::infinity()};
     Eigen::Vector3d closest_point;
     Eigen::Vector3d tangent;
     double curvature;
@@ -150,7 +148,7 @@ class Path {
     }
   }
 
-  int getCurrentSegmentIndex(const Eigen::Vector3d &position, double epsilon = 0.1) {
+  int getCurrentSegmentIndex(const Eigen::Vector3d &position) {
     Eigen::Vector3d closest_point;
     Eigen::Vector3d tangent;
     double curvature;

--- a/terrain_navigation/include/terrain_navigation/path_segment.h
+++ b/terrain_navigation/include/terrain_navigation/path_segment.h
@@ -48,7 +48,7 @@ struct State {
   Eigen::Vector4d attitude;
 };
 
-static void wrap_2pi(double &angle) {
+inline void wrap_2pi(double &angle) {
   while ((angle < 0.0) || (angle > 2 * M_PI)) {
     if (angle < 0.0) {
       angle += 2 * M_PI;
@@ -58,7 +58,7 @@ static void wrap_2pi(double &angle) {
   }
 }
 
-static void wrap_pi(double &angle) {
+inline void wrap_pi(double &angle) {
   while (std::abs(angle) > M_PI) {
     if (angle > 0)
       angle = angle - 2 * M_PI;
@@ -207,7 +207,7 @@ class PathSegment {
     if (states.size() == 1) {
       // Segment only contains a single state, meaning that it is nor a line or a arc
       theta = 1.0;
-    } else if (std::abs(curvature) < 0.0001) {
+    } else if (std::abs(curvature) < epsilon) {
       // Compute closest point on a line segment
       // Get Path Progress
       theta = getLineProgress(position, segment_start, segment_end);

--- a/terrain_planner/src/DubinsAirplane.cpp
+++ b/terrain_planner/src/DubinsAirplane.cpp
@@ -1256,7 +1256,6 @@ void DubinsAirplaneStateSpace::getStateOnCircle(const ob::State* from, int rl /*
 }
 
 unsigned int DubinsAirplaneStateSpace::convert_idx(unsigned int i) const {
-  assert(i >= 0u && "In convert_idx, i < 0");
   assert(i < 6u && "In convert_idx, i > 5");
   switch (i) {
     case 0:  // start helix


### PR DESCRIPTION
This removes the compiler warnings. A few of the functions had unused `epsilon` values. 

In `getClosestPoint`, I used the epsilon value from the function in a place that seems correct, however they were different by an order of magnitude. If you think that's wrong, let me know.

