### PR TITLE
Add flight stack combo box to planning panel

### DIFF
--- a/mav_planning_rviz/include/mav_planning_rviz/planning_panel.h
+++ b/mav_planning_rviz/include/mav_planning_rviz/planning_panel.h
@@ -16,11 +16,13 @@
 #include "mav_planning_rviz/pose_widget.h"
 #endif
 
-enum PLANNER_STATE { HOLD = 1, NAVIGATE = 2, ROLLOUT = 3, ABORT = 4, RETURN = 5 };
-
 class QLineEdit;
 class QCheckBox;
+class QComboBox;
 namespace mav_planning_rviz {
+
+enum PLANNER_STATE { HOLD = 1, NAVIGATE = 2, ROLLOUT = 3, ABORT = 4, RETURN = 5 };
+enum FLIGHT_STACK { FLIGHT_STACK_NONE = 0, PX4 = 1, ARDUPILOT = 2 };
 
 class PlanningPanel : public rviz_common::Panel {
   // This class uses Qt slots and is a subclass of QObject, so it needs
@@ -57,6 +59,7 @@ class PlanningPanel : public rviz_common::Panel {
   // Next come a couple of public Qt slots.
  public Q_SLOTS:
   void updatePlannerName();
+  void updateFlightStack();
   void updatePlanningBudget();
   void setPlannerName();
   void startEditing(const std::string& id);
@@ -107,6 +110,7 @@ class PlanningPanel : public rviz_common::Panel {
   // QT stuff:
   QLineEdit* namespace_editor_;
   QLineEdit* planner_name_editor_;
+  QComboBox* flight_stack_combobox_;
   QLineEdit* odometry_topic_editor_;
   QLineEdit* planning_budget_editor_;
   QCheckBox* terrain_align_checkbox_;
@@ -141,6 +145,10 @@ class PlanningPanel : public rviz_common::Panel {
 
   // Other state:
   std::string currently_editing_;
+
+  // Select flight stack (affects offboard/guided and RTL commands)
+  QStringList flight_stack_names_ = {"px4", "ardupilot"};
+  FLIGHT_STACK flight_stack_{PX4};
 };
 
 }  // end namespace mav_planning_rviz


### PR DESCRIPTION
Add a flight stack combo box to the planning panel. This is to allow the commands issued by the _Engage Planner_ and _Disengage Planner_ buttons to be customised to each flight stack.

| Button | PX4 | ArduPilot | 
| --- | --- | --- |
| Engage | OFFBOARD | GUIDED |
| Disengage | AUTO.RTL | RTL |

Figure: flight stack combo box in rviz 
<img width="1435" alt="rviz_flight_stack_selector" src="https://github.com/ethz-asl/terrain-navigation/assets/24916364/41797e2b-21c0-492d-bdc0-0fe1d7625142">

### Alternatives

An alternative would be to subscribe to mavros topic advertising the flight stack and use this instead of the combo. Setting the choice in the GUI seemed more straightforward and provides visible feedback of the choice made.