### PR TITLE
ros2: set bit mask in global position setpoint

### DIFF
--- a/terrain_navigation_ros/src/terrain_planner.cpp
+++ b/terrain_navigation_ros/src/terrain_planner.cpp
@@ -765,7 +765,8 @@ void TerrainPlanner::publishGlobalPositionSetpoints(
   mavros_msgs::msg::GlobalPositionTarget msg;
   msg.header.stamp = this->get_clock()->now();
   msg.coordinate_frame = mavros_msgs::msg::GlobalPositionTarget::FRAME_GLOBAL_REL_ALT;
-  msg.type_mask = 0.0;
+  msg.type_mask =
+      mavros_msgs::msg::GlobalPositionTarget::IGNORE_YAW | mavros_msgs::msg::GlobalPositionTarget::IGNORE_YAW_RATE;
   msg.latitude = latitude;
   msg.longitude = longitude;
   msg.altitude = altitude - local_origin_altitude_;
@@ -790,7 +791,7 @@ void TerrainPlanner::publishPositionSetpoints(rclcpp::Publisher<mavros_msgs::msg
   mavros_msgs::msg::PositionTarget msg;
   msg.header.stamp = this->get_clock()->now();
   msg.coordinate_frame = mavros_msgs::msg::PositionTarget::FRAME_LOCAL_NED;
-  msg.type_mask = 0.0;
+  msg.type_mask = mavros_msgs::msg::PositionTarget::IGNORE_YAW | mavros_msgs::msg::PositionTarget::IGNORE_YAW_RATE;
   msg.position.x = position(0);
   msg.position.y = position(1);
   msg.position.z = position(2);


### PR DESCRIPTION
Set the [`POSITION_TARGET_TYPEMASK`](https://mavlink.io/en/messages/common.html#POSITION_TARGET_TYPEMASK) field in the global position setpoint. This is required by the flight controller to select the appropriate control behaviour.

For example in ArduPilot Plane there is a separate handler to respond to an off-board change altitude request.

For path following we mark `lat_int`, `lon_int`, `alt`, `vx`, `vy`, `vz`, `ax`, `ay`, `az` as not ignored.