### PR TITLE
Add Mcts info message

### DIFF
--- a/planner_msgs/CMakeLists.txt
+++ b/planner_msgs/CMakeLists.txt
@@ -10,6 +10,7 @@ add_message_files(
   FILES
   NavigationStatus.msg
   TerrainInfo.msg
+  MctsInfo.msg
 )
 
 add_service_files(

--- a/planner_msgs/msg/MctsInfo.msg
+++ b/planner_msgs/msg/MctsInfo.msg
@@ -1,0 +1,6 @@
+# Terrain Information
+#
+
+std_msgs/Header header
+
+std_msgs/Int32 number_iterations


### PR DESCRIPTION
**Problem Definition**
This expands the `planner_msgs` to include MCTS information messages.

We probably need to pull this out from the package later, but including it in for now