### PR TITLE
Fix geoconversions

### DIFF
--- a/terrain_navigation_ros/include/terrain_navigation_ros/geo_conversions.h
+++ b/terrain_navigation_ros/include/terrain_navigation_ros/geo_conversions.h
@@ -75,7 +75,7 @@ class GeoConversions {
                      194.56 * std::pow(lon_aux, 2) * lat_aux + 119.79 * std::pow(lat_aux, 3);
     x = N - 1000000.00;
 
-    h = alt - 49.55 + 2.73 * lon_aux + 6.84 * lat_aux;
+    h = alt - 49.55 + 2.73 * lon_aux + 6.94 * lat_aux;
   };
 
   /**


### PR DESCRIPTION
**Problem Description**
There was a typo in the geoconversion implementation, resulting in around 10cm error of the altitude

Reference: https://github.com/ValentinMinder/Swisstopo-WGS84-LV03