### PR TITLE
Skip nuttx for terrain navigation setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ First set up the PX4 development environment:
 ```bash
 git clone https://github.com/srmainwaring/PX4-AutoPilot --branch prs/pr-hinwil-testing-rebased --recursive
 cd PX4-AutoPilot
-./Tools/setup/ubuntu.sh
+./Tools/setup/ubuntu.sh --no-nuttx
 ```
 
 Now, configure the shell environment to run `gz_standard_vtol`.


### PR DESCRIPTION
#  Purpose

Skip the nuttx setup to speed things up and reduce chances of setup failure. The README is only for px4_sitl.

https://docs.px4.io/main/en/dev_setup/dev_env_linux_ubuntu.html#simulation-and-nuttx-pixhawk-targets



