### PR TITLE
Show error message when data logger fails to write

### DIFF
--- a/terrain_navigation/src/data_logger.cpp
+++ b/terrain_navigation/src/data_logger.cpp
@@ -41,6 +41,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <cstring>
 
 DataLogger::DataLogger() {}
 
@@ -53,6 +54,10 @@ void DataLogger::writeToFile(const std::string path) {
   std::cout << "[DataLogger] Writing data to file! " << path << std::endl;
   std::ofstream output_file;
   output_file.open(path, std::ios::trunc);
+  if (output_file.fail()) {
+    std::cerr << "[DataLogger]: Failed to write to file: " << path << " with error " << strerror(errno) << std::endl;
+    return;
+  }
   if (print_header_) {
     for (auto key : keys_) {
       output_file << key << field_seperator;


### PR DESCRIPTION
# Details

* I observed the benchmarks failing to write the output csv, but no error reported
* Now, an error is reported if it fails to write the data

# New Behavior

```
$ ros2 launch terrain_planner_benchmark goaltype_benchmark.launch runs:=0
.... 

[terrain_planner_benchmark_node-2] Loading color layer from GeoTIFF file for gridmap
[terrain_planner_benchmark_node-2] Width: 559 Height: 495 Resolution: 10
[terrain_planner_benchmark_node-2] [DataLogger] Writing data to file! /home/ryan/Dev/terrain_nav_ws/install/terrain_planner/share/terrain_planner/../output/davosdorf_goal_benchmark.csv
[terrain_planner_benchmark_node-2] [DataLogger]: Failed to write to file: /home/ryan/Dev/terrain_nav_ws/install/terrain_planner/share/terrain_planner/../output/davosdorf_goal_benchmark.csv with error No such file or directory
[INFO] [terrain_planner_benchmark_node-2]: process has finished cleanly [pid 85063
```