### PR TITLE
Allow any clang version

### DIFF
--- a/Tools/fix_code_style.sh
+++ b/Tools/fix_code_style.sh
@@ -13,9 +13,9 @@ fi
 for arg in "$@"
 do
     if [ -f $arg ]; then
-        clang-format-6.0 -i -style='{BasedOnStyle: google, ColumnLimit: 120}' $arg
+        clang-format -i -style='{BasedOnStyle: google, ColumnLimit: 120}' $arg
     elif [ -d $arg ]; then
-        find $arg -iname '*.h' -o -iname '*.cpp' -o -iname '*.hpp' | xargs clang-format-6.0 -i -style='{BasedOnStyle: google, ColumnLimit: 120}'
+        find $arg -iname '*.h' -o -iname '*.cpp' -o -iname '*.hpp' | xargs clang-format -i -style='{BasedOnStyle: google, ColumnLimit: 120}'
         find $arg -iname '*.h' -o -iname '*.cpp' -o -iname '*.hpp' | xargs chmod 644
     fi
 done


### PR DESCRIPTION
# Purpose

Allow the code formatter to work in Ubuntu 22 (works in ubuntu 22 for ROS humble OS)

# Details

Same as https://github.com/ethz-asl/grid_map_geo/pull/45/files#diff-6e3bbb8833fde95ae0805dc76d97ff3e77bc2443293b86211a0fac47ae8ce475R16

