### PR TITLE
Pull in grid_map through binaries

### DIFF
--- a/terrain-navigation.repos
+++ b/terrain-navigation.repos
@@ -1,8 +1,4 @@
 repositories:
-  ANYbotics/grid_map:
-    type: git
-    url: https://github.com/ANYbotics/grid_map.git
-    version: humble
   ethz-asl/grid_map_geo:
     type: git
     url: https://github.com/ethz-asl/grid_map_geo.git


### PR DESCRIPTION
This will speed things local builds and CI up. Now that I completed a release of grid_map with modern CMake to `humble`, we can stop relying on a source build of it. 