### PR TITLE
Expand usage to non-CH1903 Geotiffs

### DIFF
--- a/terrain_navigation/test/test_terrain_map.cpp
+++ b/terrain_navigation/test/test_terrain_map.cpp
@@ -11,11 +11,11 @@ TEST(TerrainMapTest, geoTransform) {
   Eigen::Vector3d berghaus_wgs84(9.9219592, 46.7209147, 488.0);
 #endif
   Eigen::Vector3d berghaus_lv03(789823.96735451114, 177416.47911055354, 440.3752994351089);
-  Eigen::Vector3d tranformed_lv03 = TerrainMap::transformCoordinates(ESPG::WGS84, ESPG::CH1903_LV03, berghaus_wgs84);
+  Eigen::Vector3d tranformed_lv03 = TerrainMap::transformCoordinates(EPSG::WGS84, EPSG::CH1903_LV03, berghaus_wgs84);
   EXPECT_NEAR(tranformed_lv03(0), berghaus_lv03(0), 0.0001);
   EXPECT_NEAR(tranformed_lv03(1), berghaus_lv03(1), 0.0001);
   EXPECT_NEAR(tranformed_lv03(2), berghaus_lv03(2), 0.0001);
-  Eigen::Vector3d tranformed_wgs84 = TerrainMap::transformCoordinates(ESPG::CH1903_LV03, ESPG::WGS84, berghaus_lv03);
+  Eigen::Vector3d tranformed_wgs84 = TerrainMap::transformCoordinates(EPSG::CH1903_LV03, EPSG::WGS84, berghaus_lv03);
   EXPECT_NEAR(tranformed_wgs84(0), berghaus_wgs84(0), 0.0001);
   EXPECT_NEAR(tranformed_wgs84(1), berghaus_wgs84(1), 0.0001);
   EXPECT_NEAR(tranformed_wgs84(2), berghaus_wgs84(2), 0.0001);
@@ -29,7 +29,7 @@ TEST(TerrainMapTest, geoTransform) {
       "PARAMETER[\"rectified_grid_angle\", 90], PARAMETER[\"scale_factor\", 1], PARAMETER[\"false_easting\", 600000], "
       "PARAMETER[\"false_northing\", 200000], UNIT[\"metre\", 1, AUTHORITY[\"EPSG\", \"9001\"]], AXIS[\"Y\", EAST], "
       "AXIS[\"X\", NORTH], AUTHORITY[\"EPSG\", \"21781\"]]";
-  Eigen::Vector3d tranformed_lv032 = TerrainMap::transformCoordinates(ESPG::WGS84, wkt, berghaus_wgs84);
+  Eigen::Vector3d tranformed_lv032 = TerrainMap::transformCoordinates(EPSG::WGS84, wkt, berghaus_wgs84);
   EXPECT_NEAR(tranformed_lv032(0), berghaus_lv03(0), 0.0001);
   EXPECT_NEAR(tranformed_lv032(1), berghaus_lv03(1), 0.0001);
   EXPECT_NEAR(tranformed_lv032(2), berghaus_lv03(2), 0.0001);

--- a/terrain_navigation_ros/include/terrain_navigation_ros/geo_conversions.h
+++ b/terrain_navigation_ros/include/terrain_navigation_ros/geo_conversions.h
@@ -36,11 +36,28 @@
 #define GEOCONVERSIONS_H
 
 #include <math.h>
+#include <Eigen/Dense>
+
+enum class EPSG { ECEF = 4978, WGS84 = 4326, WGS84_32N = 32632, CH1903_LV03 = 21781, AT_GK_West = 31254 };
+
+/**
+ * @brief Helper function for transforming using gdal
+ *
+ * @param src_coord
+ * @param tgt_coord
+ * @param source_coordinates
+ * @return Eigen::Vector3d
+ */
 
 class GeoConversions {
  public:
   GeoConversions();
   virtual ~GeoConversions();
+
+  Eigen::Vector3d transformCoordinates(EPSG src_coord, EPSG tgt_coord, const Eigen::Vector3d source_coordinates);
+
+ private:
+  Eigen::Vector3d _transformUsingGDAL(EPSG src_coord, EPSG tgt_coord, const Eigen::Vector3d source_coordinates);
 
   /**
    * @brief Convert WGS84 (LLA) to LV03/CH1903
@@ -52,31 +69,7 @@ class GeoConversions {
    * @param y
    * @param h
    */
-  static void forward(const double lat, const double lon, const double alt, double &y, double &x, double &h) {
-    // 1. Convert the ellipsoidal latitudes φ and longitudes λ into arcseconds ["]
-    const double lat_arc = lat * 3600.0;
-    const double lon_arc = lon * 3600.0;
-
-    // 2. Calculate the auxiliary values (differences of latitude and longitude relative to Bern in the unit [10000"]):
-    //  φ' = (φ – 169028.66 ")/10000
-    //  λ' = (λ – 26782.5 ")/10000
-    const double lat_aux = (lat_arc - 169028.66) / 10000.0;
-    const double lon_aux = (lon_arc - 26782.5) / 10000.0;
-
-    // 3. Calculate projection coordinates in LV95 (E, N, h) or in LV03 (y, x, h)
-    // E [m] = 2600072.37 + 211455.93 * λ' - 10938.51 * λ' * φ' - 0.36 * λ' * φ'2 - 44.54 * λ'3
-    // y [m] = E – 2000000.00 N [m] = 1200147.07 + 308807.95 * φ' + 3745.25 * λ'2 + 76.63 * φ'2 - 194.56 * λ'2 * φ' +
-    // 119.79 * φ'3 x [m] = N – 1000000.00
-    // hCH [m] =hWGS – 49.55 + 2.73 * λ' + 6.94 * φ'
-    const double E = 2600072.37 + 211455.93 * lon_aux - 10938.51 * lon_aux * lat_aux -
-                     0.36 * lon_aux * std::pow(lat_aux, 2) - 44.54 * std::pow(lon_aux, 3);
-    y = E - 2000000.00;
-    const double N = 1200147.07 + 308807.95 * lat_aux + 3745.25 * std::pow(lon_aux, 2) + 76.63 * std::pow(lat_aux, 2) -
-                     194.56 * std::pow(lon_aux, 2) * lat_aux + 119.79 * std::pow(lat_aux, 3);
-    x = N - 1000000.00;
-
-    h = alt - 49.55 + 2.73 * lon_aux + 6.94 * lat_aux;
-  };
+  static void _forward(const double lat, const double lon, const double alt, double &y, double &x, double &h);
 
   /**
    * @brief  LV03/CH1903 to Convert WGS84 (LLA)
@@ -88,29 +81,7 @@ class GeoConversions {
    * @param lon longitude
    * @param alt altitude
    */
-  static void reverse(const double y, const double x, const double h, double &lat, double &lon, double &alt) {
-    // 1. Convert the projection coordinates E (easting) and N (northing) in LV95 (or y / x in LV03) into the civilian
-    // system (Bern = 0 / 0) and express in the unit [1000 km]: E' = (E – 2600000 m)/1000000 = (y – 600000 m)/1000000
-    // N' = (N – 1200000 m)/1000000 = (x – 200000 m)/1000000
-    const double y_aux = (y - 600000.0) / 1000000.0;
-    const double x_aux = (x - 200000.0) / 1000000.0;
-
-    // 2. Calculate longitude λ and latitude φ in the unit [10000"]:
-    //  λ' = 2.6779094 + 4.728982 * y' + 0.791484* y' * x' + 0.1306 * y' * x'2 - 0.0436 * y'3
-    //  φ' = 16.9023892 + 3.238272 * x' - 0.270978 * y'2 - 0.002528 * x'2 - 0.0447 * y'2 * x' - 0.0140 * x'3
-    // hWGS [m] = hCH + 49.55 - 12.60 * y' - 22.64 * x'
-    const double lon_aux = 2.6779094 + 4.728982 * y_aux + 0.791484 * y_aux * x_aux +
-                           0.1306 * y_aux * std::pow(x_aux, 2) - 0.0436 * std::pow(y_aux, 3);
-    const double lat_aux = 16.9023892 + 3.238272 * x_aux - 0.270978 * std::pow(y_aux, 2) -
-                           0.002528 * std::pow(x_aux, 2) - 0.0447 * std::pow(y_aux, 2) * x_aux -
-                           0.0140 * std::pow(x_aux, 3);
-    alt = h + 49.55 - 12.60 * y_aux - 22.64 * x_aux;
-
-    lon = lon_aux * 100.0 / 36.0;
-    lat = lat_aux * 100.0 / 36.0;
-  };
-
- private:
+  static void _reverse(const double y, const double x, const double h, double &lat, double &lon, double &alt);
 };
 
 #endif

--- a/terrain_navigation_ros/src/geo_conversions.cpp
+++ b/terrain_navigation_ros/src/geo_conversions.cpp
@@ -1,0 +1,89 @@
+
+#include <terrain_navigation_ros/geo_conversions.h>
+
+Eigen::Vector3d GeoConversions::transformCoordinates(EPSG src_coord, EPSG tgt_coord,
+                                                     const Eigen::Vector3d source_coordinates) {
+  Eigen::Vector3d target_coordinates;
+  if (src_coord == EPSG::WGS84 && tgt_coord == EPSG::CH1903_LV03) {
+    GeoConversions::_forward(source_coordinates(0), source_coordinates(1), source_coordinates(2), target_coordinates(0),
+                             target_coordinates(1), target_coordinates(2));
+    return target_coordinates;
+  } else if (src_coord == EPSG::CH1903_LV03 && tgt_coord == EPSG::WGS84) {
+    GeoConversions::_reverse(source_coordinates(0), source_coordinates(1), source_coordinates(2), target_coordinates(0),
+                             target_coordinates(1), target_coordinates(2));
+    return target_coordinates;
+  } else
+    return GeoConversions::_transformUsingGDAL(src_coord, tgt_coord, source_coordinates);
+};
+
+Eigen::Vector3d _transformUsingGDAL(EPSG src_coord, EPSG tgt_coord, const Eigen::Vector3d source_coordinates) {
+  OGRSpatialReference source, target;
+  source.importFromEPSG(static_cast<int>(src_coord));
+  target.importFromEPSG(static_cast<int>(tgt_coord));
+
+  // Check if the EPSG are northing easting or easting northing.
+  if (target.EPSGTreatsAsNorthingEasting()) {
+    target.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+  }
+  if (source.EPSGTreatsAsNorthingEasting()) {
+    source.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+  }
+  OGRPoint p;
+  p.setX(source_coordinates(0));
+  p.setY(source_coordinates(1));
+  p.setZ(source_coordinates(2));
+  p.assignSpatialReference(&source);
+
+  p.transformTo(&target);
+  Eigen::Vector3d target_coordinates(p.getX(), p.getY(), p.getZ());
+  return target_coordinates;
+};
+
+static void GeoConversions::_forward(const double lat, const double lon, const double alt, double &y, double &x,
+                                     double &h) {
+  // 1. Convert the ellipsoidal latitudes φ and longitudes λ into arcseconds ["]
+  const double lat_arc = lat * 3600.0;
+  const double lon_arc = lon * 3600.0;
+
+  // 2. Calculate the auxiliary values (differences of latitude and longitude relative to Bern in the unit [10000"]):
+  //  φ' = (φ – 169028.66 ")/10000
+  //  λ' = (λ – 26782.5 ")/10000
+  const double lat_aux = (lat_arc - 169028.66) / 10000.0;
+  const double lon_aux = (lon_arc - 26782.5) / 10000.0;
+
+  // 3. Calculate projection coordinates in LV95 (E, N, h) or in LV03 (y, x, h)
+  // E [m] = 2600072.37 + 211455.93 * λ' - 10938.51 * λ' * φ' - 0.36 * λ' * φ'2 - 44.54 * λ'3
+  // y [m] = E – 2000000.00 N [m] = 1200147.07 + 308807.95 * φ' + 3745.25 * λ'2 + 76.63 * φ'2 - 194.56 * λ'2 * φ' +
+  // 119.79 * φ'3 x [m] = N – 1000000.00
+  // hCH [m] =hWGS – 49.55 + 2.73 * λ' + 6.94 * φ'
+  const double E = 2600072.37 + 211455.93 * lon_aux - 10938.51 * lon_aux * lat_aux -
+                   0.36 * lon_aux * std::pow(lat_aux, 2) - 44.54 * std::pow(lon_aux, 3);
+  y = E - 2000000.00;
+  const double N = 1200147.07 + 308807.95 * lat_aux + 3745.25 * std::pow(lon_aux, 2) + 76.63 * std::pow(lat_aux, 2) -
+                   194.56 * std::pow(lon_aux, 2) * lat_aux + 119.79 * std::pow(lat_aux, 3);
+  x = N - 1000000.00;
+
+  h = alt - 49.55 + 2.73 * lon_aux + 6.94 * lat_aux;
+};
+
+static void GeoConversions::_reverse(const double y, const double x, const double h, double &lat, double &lon,
+                                     double &alt) {
+  // 1. Convert the projection coordinates E (easting) and N (northing) in LV95 (or y / x in LV03) into the civilian
+  // system (Bern = 0 / 0) and express in the unit [1000 km]: E' = (E – 2600000 m)/1000000 = (y – 600000 m)/1000000
+  // N' = (N – 1200000 m)/1000000 = (x – 200000 m)/1000000
+  const double y_aux = (y - 600000.0) / 1000000.0;
+  const double x_aux = (x - 200000.0) / 1000000.0;
+
+  // 2. Calculate longitude λ and latitude φ in the unit [10000"]:
+  //  λ' = 2.6779094 + 4.728982 * y' + 0.791484* y' * x' + 0.1306 * y' * x'2 - 0.0436 * y'3
+  //  φ' = 16.9023892 + 3.238272 * x' - 0.270978 * y'2 - 0.002528 * x'2 - 0.0447 * y'2 * x' - 0.0140 * x'3
+  // hWGS [m] = hCH + 49.55 - 12.60 * y' - 22.64 * x'
+  const double lon_aux = 2.6779094 + 4.728982 * y_aux + 0.791484 * y_aux * x_aux + 0.1306 * y_aux * std::pow(x_aux, 2) -
+                         0.0436 * std::pow(y_aux, 3);
+  const double lat_aux = 16.9023892 + 3.238272 * x_aux - 0.270978 * std::pow(y_aux, 2) - 0.002528 * std::pow(x_aux, 2) -
+                         0.0447 * std::pow(y_aux, 2) * x_aux - 0.0140 * std::pow(x_aux, 3);
+  alt = h + 49.55 - 12.60 * y_aux - 22.64 * x_aux;
+
+  lon = lon_aux * 100.0 / 36.0;
+  lat = lat_aux * 100.0 / 36.0;
+};

--- a/terrain_navigation_ros/src/terrain_planner.cpp
+++ b/terrain_navigation_ros/src/terrain_planner.cpp
@@ -171,16 +171,18 @@ void TerrainPlanner::cmdloopCallback(const ros::TimerEvent &event) {
     double path_progress = current_segment.getClosestPoint(vehicle_position_, reference_position, reference_tangent,
                                                            reference_curvature, 1.0);
     // Publish global position setpoints in the global frame
-    ESPG map_coordinate;
+    EPSG map_coordinate;
     Eigen::Vector3d map_origin;
     terrain_map_->getGlobalOrigin(map_coordinate, map_origin);
     /// TODO: convert reference position to global
     const Eigen::Vector3d lv03_reference_position = reference_position + map_origin;
-    double latitude;
-    double longitude;
-    double altitude;
-    GeoConversions::reverse(lv03_reference_position(0), lv03_reference_position(1), lv03_reference_position(2),
-                            latitude, longitude, altitude);
+    Eigen::Vector3d wgs84_reference_position =
+        GeoConversions::transformCoordinates(EPSG::CH1903_LV03, EPSG::WGS84, lv03_reference_position);
+
+    double latitude = wgs84_reference_position(0);
+    double longitude = wgs84_reference_position(1);
+    double altitude = wgs84_reference_position(2);
+
     publishReferenceMarker(position_target_pub_, reference_position, reference_tangent, reference_curvature);
 
     // Run additional altitude control
@@ -275,7 +277,7 @@ void TerrainPlanner::plannerloopCallback(const ros::TimerEvent &event) {
     terrain_map_->AddLayerHorizontalDistanceTransform(-goal_radius_, "ics_-", "max_elevation");
     terrain_map_->addLayerSafety("safety", "ics_+", "ics_-");
 
-    ESPG map_coordinate;
+    EPSG map_coordinate;
     Eigen::Vector3d map_origin;
     terrain_map_->getGlobalOrigin(map_coordinate, map_origin);
 
@@ -609,19 +611,17 @@ void TerrainPlanner::mavGlobalPoseCallback(const sensor_msgs::NavSatFix &msg) {
   wgs84_vehicle_position(1) = msg.longitude;
   wgs84_vehicle_position(2) = msg.altitude;
 
-  ESPG map_coordinate;
+  EPSG map_coordinate;
   Eigen::Vector3d map_origin;
   terrain_map_->getGlobalOrigin(map_coordinate, map_origin);
 
-  if (map_coordinate == ESPG::WGS84) {
-    GeoConversions::forward(map_origin(0), map_origin(1), map_origin(2), map_origin.x(), map_origin.y(),
-                            map_origin.z());
+  if (map_coordinate == EPSG::WGS84) {
+    map_origin = GeoConversions::transformCoordinates(EPSG::WGS84, EPSG::CH1903_LV03, map_origin);
   }
 
-  Eigen::Vector3d transformed_coordinates;
   // LV03 / WGS84 ellipsoid
-  GeoConversions::forward(wgs84_vehicle_position(0), wgs84_vehicle_position(1), wgs84_vehicle_position(2),
-                          transformed_coordinates.x(), transformed_coordinates.y(), transformed_coordinates.z());
+  Eigen::Vector3d transformed_coordinates =
+      GeoConversions::transformCoordinates(EPSG::WGS84, EPSG::CH1903_LV03, wgs84_vehicle_position);
   vehicle_position_ = transformed_coordinates - map_origin;
 }
 
@@ -862,17 +862,16 @@ void TerrainPlanner::mavMissionCallback(const mavros_msgs::WaypointListPtr &msg)
         std::cout << " - Radius: " << waypoint.param3 << std::endl;
         double waypoint_altitude = waypoint.z_alt + local_origin_altitude_;
         const double loiter_radius = waypoint.param3;
-        Eigen::Vector3d lv03_mission_loiter_center;
-        GeoConversions::forward(waypoint.x_lat, waypoint.y_long, waypoint_altitude, lv03_mission_loiter_center.x(),
-                                lv03_mission_loiter_center.y(), lv03_mission_loiter_center.z());
+        Eigen::Vector3d lv03_mission_loiter_center = GeoConversions::transformCoordinates(
+            EPSG::WGS84, EPSG::CH1903_LV03, Eigen::Vector3d(waypoint.x_lat, waypoint.y_long, waypoint_altitude));
+        ;
         std::cout << "mission_loiter_center_: " << lv03_mission_loiter_center.transpose() << std::endl;
-        ESPG map_coordinate;
+        EPSG map_coordinate;
         Eigen::Vector3d map_origin;
         terrain_map_->getGlobalOrigin(map_coordinate, map_origin);
 
-        if (map_coordinate == ESPG::WGS84) {
-          GeoConversions::forward(map_origin(0), map_origin(1), map_origin(2), map_origin.x(), map_origin.y(),
-                                  map_origin.z());
+        if (map_coordinate == EPSG::WGS84) {
+          map_origin = GeoConversions::transformCoordinates(EPSG::WGS84, EPSG::CH1903_LV03, map_origin);
         }
         mission_loiter_center_ = lv03_mission_loiter_center - map_origin;
         mission_loiter_radius_ = loiter_radius;
@@ -905,14 +904,15 @@ bool TerrainPlanner::setLocationCallback(planner_msgs::SetString::Request &req,
 
   if (!align_location) {
     // Depending on Gdal versions, lon lat order are reversed
-    Eigen::Vector3d lv03_local_origin;
-    GeoConversions::forward(local_origin_latitude_, local_origin_longitude_, local_origin_altitude_,
-                            lv03_local_origin.x(), lv03_local_origin.y(), lv03_local_origin.z());
+    Eigen::Vector3d lv03_local_origin = GeoConversions::transformCoordinates(
+        EPSG::WGS84, EPSG::CH1903_LV03,
+        Eigen::Vector3d(local_origin_latitude_, local_origin_longitude_, local_origin_altitude_));
+
     if (terrain_map_->getGridMap().isInside(Eigen::Vector2d(0.0, 0.0))) {
       double terrain_altitude = terrain_map_->getGridMap().atPosition("elevation", Eigen::Vector2d(0.0, 0.0));
       lv03_local_origin(2) = lv03_local_origin(2) - terrain_altitude;
     }
-    terrain_map_->setGlobalOrigin(ESPG::CH1903_LV03, lv03_local_origin);
+    terrain_map_->setGlobalOrigin(EPSG::CH1903_LV03, lv03_local_origin);
   }
   if (result) {
     global_planner_->setBoundsFromMap(terrain_map_->getGridMap());


### PR DESCRIPTION
-Renamed ESPG to EPSG, as it stands for the European Petroleum Survey Group Geodesy
-Added support for non CH1903-WGS84 Transfor using GDAL