### PR TITLE
Per-segment speed reference profile and path ID

### DIFF
--- a/planner_msgs/msg/Path.msg
+++ b/planner_msgs/msg/Path.msg
@@ -4,3 +4,4 @@
 std_msgs/Header header
 
 PathSegment[] segments
+uint8 id

--- a/planner_msgs/msg/PathSegment.msg
+++ b/planner_msgs/msg/PathSegment.msg
@@ -9,4 +9,5 @@ std_msgs/Float64 segment_length
 geometry_msgs/Vector3 segment_start
 geometry_msgs/Vector3 segment_tangent
 std_msgs/Float64 curvature
-
+std_msgs/Float64 vd_start
+std_msgs/Float64 vd_end


### PR DESCRIPTION
Added fields to define
- Path-ID to detect switch of reference in predictive guidance & update related solver quantities
- Linear speed profile for more flexible mission definitions. E.g. to define hover<->cruise transition profiles for hybrid UAVs